### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
   "name": "gulp-token-replace",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "A token replace plugin for gulp",
   "main": "index.js",
   "devDependencies": {
-    "should": "~4.0.x",
-    "mocha": "~1.21.x",
-    "gulp": "~3.8.x",
+    "should": "~11.2.x",
+    "mocha": "~3.4.x",
+    "gulp": "~3.9.x",
     "gulp-util": "~3.0.x"
   },
   "dependencies": {
-    "concat-stream": "~1.4.x",
+    "concat-stream": "~1.6.x",
     "gulp-util": "~3.0.x",
-    "event-stream": "~3.1.x"
+    "event-stream": "~3.3.x"
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha"


### PR DESCRIPTION
* Update package.json to use latest version of dependencies.
* Bump version to 1.0.4

This allows gulp-token-replace and eslint to use the same version of concat-stream.
Additionally npm has a version 1.0.3 published I can't find in git, so I skipped to 1.0.4 for this change.